### PR TITLE
Removing views from scala code.

### DIFF
--- a/scala/src/main/scala/ClashOfLambdas.scala
+++ b/scala/src/main/scala/ClashOfLambdas.scala
@@ -91,7 +91,6 @@ package benchmarks {
     def sumPar () : Long = {
       val sum : Long = v
 	.par
-	.view
 	.sum
       sum
     }
@@ -99,7 +98,6 @@ package benchmarks {
     @GenerateMicroBenchmark
     def sumOfSquaresSeq () : Long = {
       val sum : Long = v
-      .view
       .map(d => d * d)
       .sum
       sum
@@ -109,7 +107,6 @@ package benchmarks {
     def sumOfSquaresPar () : Long = {
       val sum : Long = v
 	.par
-	.view
 	.map(d => d * d)
 	.sum
       sum
@@ -118,8 +115,7 @@ package benchmarks {
     @GenerateMicroBenchmark
     def cartSeq () : Long = {
       val sum : Long = vHi
-	.view
-	.flatMap(d => vLo.view.map (dp => dp * d))
+	.flatMap(d => vLo.map (dp => dp * d))
 	.sum
       sum
     }
@@ -128,8 +124,7 @@ package benchmarks {
     def cartPar () : Long = {
       val sum : Long = vHi
 	.par
-	.view
-	.flatMap(d => vLo.view.map (dp => dp * d))
+	.flatMap(d => vLo.map (dp => dp * d))
 	.sum
       sum
     }
@@ -147,7 +142,6 @@ package benchmarks {
     def sumOfSquaresEvenPar () : Long = {
       val res : Long = v
 	.par
-	.view
 	.filter(x => x % 2 == 0)
 	.map(x => x * x)
 	.sum
@@ -177,7 +171,7 @@ package benchmarks {
     def cartSeqOpt () : Long = {
       optimize {
 	val sum : Long = vHi
-	  .flatMap(d => vLo.view.map (dp => dp * d))
+	  .flatMap(d => vLo.map (dp => dp * d))
 	  .sum
 	sum
       }


### PR DESCRIPTION
Scala views don't interop with parallel collections well,
constructions like col.par.view and col.view.par are known to be broken.
Moreover none of functionality of views is used in those benchmarks,
so usage of views seems unnecessary.
