### PR TITLE
Benchmark a scala "speed" optimized version

### DIFF
--- a/results/process
+++ b/results/process
@@ -44,18 +44,23 @@ function printLang (filename, lang) {
     if (lang == "scala") {
 	printBenchOfLang(filename, lang,"sumSeq_Strict")
 	printBenchOfLang(filename, lang,"sumPar_Strict")
+	printBenchOfLang(filename, lang,"sumSpeedy")
 
 	printBenchOfLang(filename, lang,"sumOfSquaresSeq_Strict")
 	printBenchOfLang(filename, lang,"sumOfSquaresPar_Strict")
+	printBenchOfLang(filename, lang,"sumOfSquaresSpeedy")
 
 	printBenchOfLang(filename, lang,"sumOfSquaresEvenSeq_Strict")
 	printBenchOfLang(filename, lang,"sumOfSquaresEvenPar_Strict")
+	printBenchOfLang(filename, lang,"sumOfSquaresEvenSpeedy")
 
 	printBenchOfLang(filename, lang,"cartSeq_Strict")
 	printBenchOfLang(filename, lang,"cartPar_Strict")
+	printBenchOfLang(filename, lang,"cartParSpeedy")
 
 	printBenchOfLang(filename, lang,"refSeq_Strict")
 	printBenchOfLang(filename, lang,"refPar_Strict")
+	printBenchOfLang(filename, lang,"refSpeedy")
     }
 }
 

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -31,6 +31,12 @@
       <artifactId>scala-library</artifactId>
       <version>2.10.4</version>
     </dependency>
+    <dependency>
+        <groupId>net.virtual-void</groupId>
+        <artifactId>speed_2.10</artifactId>
+        <version>13</version>
+        <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <prerequisites>

--- a/scala/src/main/scala/ClashOfLambdas.scala
+++ b/scala/src/main/scala/ClashOfLambdas.scala
@@ -311,6 +311,43 @@ package benchmarks {
 	.seq.size // the `size` method is not defined on the `Par` wrapper 
       res
     }
+
+    // speedy tests
+    @GenerateMicroBenchmark
+    def sumSpeedy(): Long = {
+      import speed._
+      v.sum
+    }
+    @GenerateMicroBenchmark
+    def sumOfSquaresSpeedy(): Long = {
+      import speed._
+      v.map(d ⇒ d * d).sum
+    }
+    @GenerateMicroBenchmark
+    def cartSpeedy(): Long = {
+      import speed._
+      (for {
+        d ← vHi
+        dp ← vLo
+      } yield dp * d).sum
+    }
+    @GenerateMicroBenchmark
+    def sumOfSquaresEvenSpeedy(): Long = {
+      import speed._
+      v.filter(_ % 2 == 0)
+        .map(x ⇒ x * x)
+        .sum
+    }
+    @GenerateMicroBenchmark
+    def refSpeedy(): Int = {
+      import speed._
+      val res: Int = refs
+        .filter(_.num % 5 == 0)
+        .filter(_.num % 7 == 0)
+        .size
+      res
+    }
+
     
     ///////////////////////////////////////
     // Benchmarks without Views (strict) //


### PR DESCRIPTION
This adds an alternatively optimized Scala version using my "[speed](http://github.com/jrudolph/speed)" library. I just released a new version of it that should support all of the patterns used in the benchmark. It is still no complete, full-fledged library for every use case but it shows what the limits are for the static optimization approach.
